### PR TITLE
Install Python with file type associations on Windows

### DIFF
--- a/win64.dockerfile
+++ b/win64.dockerfile
@@ -28,10 +28,11 @@ ADD https://www.python.org/ftp/python/3.10.7/python-3.10.7-amd64.exe C:\TEMP\pyt
 RUN C:\TEMP\python_inst.exe /passive TargetDir=C:\BuildTools\python `
     Shortcuts=0 `
     Include_doc=0 `
-    Include_launcher=0 `
+    Include_launcher=1 `
     InstallLauncherAllUsers=0 `
     Include_tcltk=0 `
-    Include_test=0
+    Include_test=0 `
+    AssociateFiles=1
 
 # Install git min
 ADD https://github.com/git-for-windows/git/releases/download/v2.38.0.windows.1/MinGit-2.38.0-64-bit.zip C:\TEMP\MinGit.zip


### PR DESCRIPTION
This would allow me to write `./script.py` for both platforms instead of writing `python script.py` for Windows and `python3 script.py` or `./script.py` for Linux.